### PR TITLE
[Fix/#24]: 게시글 조회 응답에 페이지네이션 정보 추가

### DIFF
--- a/controllers/postController.js
+++ b/controllers/postController.js
@@ -65,10 +65,14 @@ const getPosts = [
       const offset = (page - 1) * limit;
       let query = "";
       let params = [];
+      let countQuery = postQuery.countQuery;
+      let countParams = [];
 
       if (myPage === "true" && userId) {
         query = postQuery.getPosts;
         params.push(userId);
+        countQuery += " WHERE writer_id = ?";
+        countParams.push(userId);
       } else {
         query = postQuery.getAllPosts;
       }
@@ -77,27 +81,39 @@ const getPosts = [
       if (search) {
         if (query.includes("WHERE")) {
           query += " AND title LIKE ?";
+          countQuery += " AND title LIKE ?";
         } else {
           query += " WHERE title LIKE ?";
+          countQuery += " WHERE title LIKE ?";
         }
         params.push(`%${search}%`);
+        countParams.push(`%${search}%`);
       }
 
       // 카테고리별 조회인 경우
       if (categoryId) {
         if (query.includes("WHERE")) {
           query += " AND category_id = ?";
+          countQuery += " AND category_id = ?";
         } else {
           query += " WHERE category_id = ?";
+          countQuery += " WHERE category_id = ?";
         }
         params.push(parseInt(categoryId));
+        countParams.push(parseInt(categoryId));
       }
 
       // 페이지네이션 적용
       query += postQuery.limitOffset;
       params.push(parseInt(limit), offset);
 
-      const result = await postService.getPosts(query, params);
+      const result = await postService.getPosts(
+        query,
+        params,
+        countQuery,
+        countParams,
+        page
+      );
 
       res.status(StatusCodes.OK).json(result);
     } catch (err) {

--- a/queries/postQuery.js
+++ b/queries/postQuery.js
@@ -12,3 +12,4 @@ exports.getPostById = `SELECT * FROM posts WHERE id = ?`;
 exports.getCommentsByPostId = `SELECT * FROM comments WHERE post_id = ?`;
 exports.getUserById = `SELECT * FROM users WHERE id = ?`;
 exports.getLinksByPostId = `SELECT * FROM links WHERE post_id =?`;
+exports.countQuery = `SELECT COUNT(*) AS total FROM posts`;

--- a/services/postService.js
+++ b/services/postService.js
@@ -32,10 +32,14 @@ const writePost = async (writerId, categoryId, title, content, links) => {
   }
 };
 
-const getPosts = async (query, params) => {
+const getPosts = async (query, params, countQuery, countParams, page) => {
   try {
     const result = await conn.query(query, params);
     const postDataList = result[0];
+
+    // 총 게시글 수
+    const countResult = await conn.query(countQuery, countParams);
+    const totalCount = countResult[0][0].total;
 
     if (postDataList.length > 0) {
       const postList = [];
@@ -67,6 +71,10 @@ const getPosts = async (query, params) => {
         isSuccess: true,
         message: "게시글 조회 성공",
         result: postList,
+        pagination: {
+          currentPage: parseInt(page),
+          totalPosts: totalCount,
+        },
       };
     } else {
       throw new CustomError(


### PR DESCRIPTION
## 📍 작업 내용

게시글 조회 API의 응답에 페이지네이션 정보 추가

<br/>

## 📍 기타 사항
pagination 안에 currentPage(현재 페이지), totalPosts(총 게시글 수) 담음

<img width="704" alt="스크린샷 2024-06-07 오후 11 23 37" src="https://github.com/Team-DevHub/dev-hub-back/assets/124678039/8274212e-db76-4204-b210-b161e07b9982">

<br/>
