### PR TITLE
[Fix/#32]: 게시글 조회 API 옵션 수정

### DIFF
--- a/controllers/postController.js
+++ b/controllers/postController.js
@@ -62,7 +62,6 @@ const getPosts = [
         }
       }
 
-      const offset = (page - 1) * limit;
       let query = "";
       let params = [];
       let countQuery = postQuery.countQuery;
@@ -103,15 +102,18 @@ const getPosts = [
         countParams.push(parseInt(categoryId));
       }
 
-      // 페이지네이션 적용
-      query += postQuery.limitOffset;
-      params.push(parseInt(limit), offset);
+      // 마이페이지 아닌 경우 페이지네이션 적용
+      if (myPage !== "true") {
+        const offset = (page - 1) * limit;
+        query += postQuery.limitOffset;
+        params.push(parseInt(limit), offset);
+      }
 
       const result = await postService.getPosts(
         query,
         params,
-        countQuery,
-        countParams,
+        myPage !== "true" ? countQuery : null,
+        myPage !== "true" ? countParams : null,
         page
       );
 

--- a/services/postService.js
+++ b/services/postService.js
@@ -38,8 +38,11 @@ const getPosts = async (query, params, countQuery, countParams, page) => {
     const postDataList = result[0];
 
     // 총 게시글 수
-    const countResult = await conn.query(countQuery, countParams);
-    const totalCount = countResult[0][0].total;
+    let totalCount = 0;
+    if (countQuery && countParams) {
+      const countResult = await conn.query(countQuery, countParams);
+      totalCount = countResult[0][0].total;
+    }
 
     if (postDataList.length > 0) {
       const postList = [];
@@ -67,15 +70,20 @@ const getPosts = async (query, params, countQuery, countParams, page) => {
         postList.push(postInfo);
       }
 
-      return {
+      const response = {
         isSuccess: true,
         message: "게시글 조회 성공",
         result: postList,
-        pagination: {
+      };
+
+      if (countQuery && countParams) {
+        response.pagination = {
           currentPage: parseInt(page),
           totalPosts: totalCount,
-        },
-      };
+        };
+      }
+
+      return response;
     } else {
       throw new CustomError(
         StatusCodes.NOT_FOUND,

--- a/utils/validation.js
+++ b/utils/validation.js
@@ -59,8 +59,14 @@ const linksValidation = () =>
   body("links").isArray().withMessage("요청 값이 유효하지 않습니다.");
 
 const postQueryValidation = () => [
-  query("limit").isInt({ min: 1 }).withMessage("요청 값이 유효하지 않습니다."),
-  query("page").isInt({ min: 1 }).withMessage("요청 값이 유효하지 않습니다."),
+  query("limit")
+    .optional()
+    .isInt({ min: 1 })
+    .withMessage("요청 값이 유효하지 않습니다."),
+  query("page")
+    .optional()
+    .isInt({ min: 1 })
+    .withMessage("요청 값이 유효하지 않습니다."),
   query("myPage")
     .optional()
     .isBoolean()


### PR DESCRIPTION
## 📍 작업 내용

마이페이지 조회시에는 페이지네이션 필요없기 때문에 limit, page 옵션 삭제
search나 categoryId 같은 경우는 limit, page 옵션 포함하도록 함
limit, page만 있는 경우는 전체 게시글 조회

<br/>

## 📍 기타 사항
**수정 후 마이페이지 조회**
<img width="754" alt="스크린샷 2024-06-10 오후 4 18 21" src="https://github.com/Team-DevHub/dev-hub-back/assets/124678039/baaa06b3-620e-44e6-90e2-6287246e2cc8">

**전체 게시글 조회**
<img width="754" alt="스크린샷 2024-06-10 오후 4 18 54" src="https://github.com/Team-DevHub/dev-hub-back/assets/124678039/3e4d8f69-0cae-4c0e-b8b9-d57031d6e9f1">

**검색어로 게시글 조회**
<img width="754" alt="스크린샷 2024-06-10 오후 4 19 40" src="https://github.com/Team-DevHub/dev-hub-back/assets/124678039/535c7366-77f7-4f72-862e-0a6b0c9b7684">

**카테고리로 게시글 조회**
<img width="754" alt="스크린샷 2024-06-10 오후 4 20 33" src="https://github.com/Team-DevHub/dev-hub-back/assets/124678039/3d26fda5-e210-4fd8-8695-f560d6ceb042">

<br/>
