### PR TITLE
[Feat/#34]: 게시글 정렬, 댓글 API 기능 추가

### DIFF
--- a/controllers/postController.js
+++ b/controllers/postController.js
@@ -102,12 +102,16 @@ const getPosts = [
         countParams.push(parseInt(categoryId));
       }
 
+      query += " ORDER BY created_at DESC";
+
       // 마이페이지 아닌 경우 페이지네이션 적용
       if (myPage !== "true") {
         const offset = (page - 1) * limit;
         query += postQuery.limitOffset;
         params.push(parseInt(limit), offset);
       }
+
+      console.log(query);
 
       const result = await postService.getPosts(
         query,

--- a/queries/commentQuery.js
+++ b/queries/commentQuery.js
@@ -1,5 +1,5 @@
 exports.writeComment = `INSERT INTO comments (content, writer_id, post_id) VALUES (?,?,?);`;
 exports.deleteComment = `DELETE FROM comments WHERE id = ? AND writer_id = ?;`;
-exports.getCommentById = `SELECT * FROM comments WHERE writer_id = ? AND id = ?;`;
 exports.getCommentsByPostId = `SELECT * FROM comments WHERE post_id = ?;`;
 exports.getCommentWriterById = `SELECT id, name, level FROM users WHERE id = ?;`;
+exports.getCommentWriter = `SELECT writer_id FROM comments WHERE id = ?`;

--- a/services/commentService.js
+++ b/services/commentService.js
@@ -3,12 +3,15 @@ const conn = require("../database/mysql");
 const { StatusCodes } = require("http-status-codes");
 const commentQuery = require("../queries/commentQuery");
 const CustomError = require("../utils/CustomError");
+const { updatePointsAndLevel } = require("../utils/updateLevel");
 
 const writeComment = async (writerId, postId, content) => {
   let values = [content, writerId, postId];
 
   try {
     await conn.query(commentQuery.writeComment, values);
+
+    await updatePointsAndLevel(writerId, 2);
 
     return {
       isSuccess: true,
@@ -21,24 +24,28 @@ const writeComment = async (writerId, postId, content) => {
 
 const deleteComment = async (writerId, commentId) => {
   try {
-    const isCommentWriter = await conn.query(commentQuery.getCommentById, [
-      writerId,
-      commentId,
-    ]);
+    // 댓글 작성자 조회
+    const commentWriterResult = await conn.query(
+      commentQuery.getCommentWriter,
+      commentId
+    );
+    const commentWriterId = commentWriterResult[0][0].writer_id;
 
-    if (isCommentWriter.length > 0) {
-      await conn.query(commentQuery.deleteComment, [commentId, writerId]);
-
-      return {
-        isSuccess: true,
-        message: "댓글 삭제 성공",
-      };
-    } else {
+    if (writerId !== commentWriterId) {
       throw new CustomError(
         StatusCodes.UNAUTHORIZED,
         "댓글을 삭제할 권한이 없습니다."
       );
     }
+
+    await conn.query(commentQuery.deleteComment, [commentId, writerId]);
+
+    await updatePointsAndLevel(writerId, -2);
+
+    return {
+      isSuccess: true,
+      message: "댓글 삭제 성공",
+    };
   } catch (err) {
     throw err;
   }


### PR DESCRIPTION
## 📍 작업 내용

- 게시글 전체 조회 시, 최신 순 정렬되도록 postController 수정 -> ORDER BY
- 댓글 작성, 삭제 시, 레벨 2포인트씩 추가/차감되는 로직 구현
- 자신의 댓글 삭제인지 확인하는 예외처리 추가


<br/>

## 📍 기타 사항

이전에 자신이 작성하지 않은 commentId를 입력해도 DB에 반영되지는 않지만 응답으로 success를 출력하는 오류를 발견해서 현재 로그인한 회원의 id와 댓글작성자 id를 비교하는 예외 처리 코드를 추가했습니다!

<br/>
