### PR TITLE
[Feat/#40]: 깃허브 소셜 로그인 구현

### DIFF
--- a/app.js
+++ b/app.js
@@ -14,6 +14,7 @@ app.listen(process.env.PORT, () => {
   console.log(`Server listening on ${process.env.PORT}...`);
 });
 
+const authRouter = require("./routes/authRouter");
 const userRouter = require("./routes/usersRouter");
 const postRouter = require("./routes/postRouter");
 const commentRouter = require("./routes/commentRouter");
@@ -21,3 +22,4 @@ const commentRouter = require("./routes/commentRouter");
 app.use("/users", userRouter);
 app.use("/posts", postRouter);
 app.use("/comments", commentRouter);
+app.use("/oauth", authRouter);

--- a/constants/url.js
+++ b/constants/url.js
@@ -1,7 +1,9 @@
 const URL = {
   github_authorize: "https://github.com/login/oauth/authorize",
   github_token: "https://github.com/login/oauth/access_token",
-  github_api: "https://api.github.com",
+  github_getEmail: "https://api.github.com/user/emails",
+  github_getUser: "https://api.github.com/user",
+  github_deleteUser: `https://api.github.com/applications/${process.env.GITHUB_CLIENT_ID}/grant`,
 };
 
 module.exports = URL;

--- a/constants/url.js
+++ b/constants/url.js
@@ -1,0 +1,7 @@
+const URL = {
+  github_authorize: "https://github.com/login/oauth/authorize",
+  github_token: "https://github.com/login/oauth/access_token",
+  github_api: "https://api.github.com",
+};
+
+module.exports = URL;

--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -38,7 +38,23 @@ const getGithubCallback = async (req, res) => {
   }
 };
 
+const deleteGithubAccount = async (req, res) => {
+  try {
+    const token = req.headers["authorization"].split(" ")[1];
+    const verifyResult = verifyAccessToken(token);
+
+    const result = await authService.deleteGithubAccount(verifyResult);
+    res.status(StatusCodes.OK).json(result);
+  } catch (err) {
+    res.status(err.statusCode || 500).json({
+      isSuccess: false,
+      message: err.message,
+    });
+  }
+};
+
 module.exports = {
   getGithubUrl,
   getGithubCallback,
+  deleteGithubAccount,
 };

--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -1,0 +1,20 @@
+const { StatusCodes } = require("http-status-codes");
+
+const getGithubUrl = (req, res) => {
+  const url = "https://github.com/login/oauth/authorize"; // github 소셜로그인 인증 서버 URL
+
+  const config = {
+    client_id: process.env.GITHUB_CLIENT_ID,
+    scope: "read:user user:email", // 서버에서 필요로 하는 정보 (유저정보, 이메일정보)
+    allow_signup: true,
+  };
+
+  const params = new URLSearchParams(config).toString();
+  const finalUrl = `${url}?${params}`;
+
+  res.status(StatusCodes.OK).json({ url: finalUrl });
+};
+
+module.exports = {
+  getGithubUrl,
+};

--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -1,7 +1,9 @@
 const { StatusCodes } = require("http-status-codes");
+const authService = require("../services/authService");
+const URL = require("../constants/url");
 
 const getGithubUrl = (req, res) => {
-  const url = "https://github.com/login/oauth/authorize"; // github 소셜로그인 인증 서버 URL
+  const url = URL.github_authorize; // github 소셜로그인 인증 서버 URL
 
   const config = {
     client_id: process.env.GITHUB_CLIENT_ID,
@@ -15,6 +17,28 @@ const getGithubUrl = (req, res) => {
   res.status(StatusCodes.OK).json({ url: finalUrl });
 };
 
+const getGithubCallback = async (req, res) => {
+  const { code } = req.body; // 인가코드
+  const tokenUrl = URL.github_token; // 토큰 요청주소
+
+  const data = {
+    client_id: process.env.GITHUB_CLIENT_ID,
+    client_secret: process.env.GITHUB_SECRET,
+    code,
+  };
+
+  try {
+    const result = await authService.getGithubCallback(tokenUrl, data);
+    res.status(StatusCodes.OK).json(result);
+  } catch (err) {
+    res.status(err.statusCode || 500).json({
+      isSuccess: false,
+      message: err.message,
+    });
+  }
+};
+
 module.exports = {
   getGithubUrl,
+  getGithubCallback,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "axios": "^1.7.2",
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
@@ -54,6 +55,21 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/axios": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
+      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -173,6 +189,17 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -245,6 +272,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/denque": {
@@ -416,6 +451,38 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/forwarded": {
@@ -1000,6 +1067,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/pstree.remy": {
       "version": "1.1.8",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "axios": "^1.7.2",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",

--- a/queries/authQuery.js
+++ b/queries/authQuery.js
@@ -1,0 +1,2 @@
+exports.githubJoin = `INSERT INTO users (id, name, email, password, salt, login_type, github_token) VALUES (?, ?, ?, ?, ?, ?, ?)`;
+exports.getGithubToken = `SELECT github_token FROM users WHERE id = ?`;

--- a/queries/userQuery.js
+++ b/queries/userQuery.js
@@ -12,3 +12,4 @@ exports.updatePoints = `UPDATE users SET points = points + ? WHERE id = ?`;
 exports.updateLevel = `UPDATE users SET level = ? WHERE id = ?`;
 exports.getPointsById = `SELECT points FROM users WHERE id = ?`;
 exports.checkNickname = `SELECT COUNT(*) as count FROM users WHERE name = ?`;
+exports.getLoginType = `SELECT login_type FROM users WHERE id = ?`;

--- a/routes/authRouter.js
+++ b/routes/authRouter.js
@@ -1,0 +1,7 @@
+const express = require("express");
+const authRouter = express.Router();
+const authController = require("../controllers/authController");
+
+authRouter.get("/github", authController.getGithubUrl);
+
+module.exports = authRouter;

--- a/routes/authRouter.js
+++ b/routes/authRouter.js
@@ -3,5 +3,6 @@ const authRouter = express.Router();
 const authController = require("../controllers/authController");
 
 authRouter.get("/github", authController.getGithubUrl);
+authRouter.post("/github", authController.getGithubCallback);
 
 module.exports = authRouter;

--- a/routes/authRouter.js
+++ b/routes/authRouter.js
@@ -4,5 +4,6 @@ const authController = require("../controllers/authController");
 
 authRouter.get("/github", authController.getGithubUrl);
 authRouter.post("/github", authController.getGithubCallback);
+authRouter.delete("/github", authController.deleteGithubAccount);
 
 module.exports = authRouter;

--- a/services/authService.js
+++ b/services/authService.js
@@ -2,10 +2,12 @@ const { default: axios } = require("axios");
 const CustomError = require("../utils/CustomError");
 const conn = require("../database/mysql");
 const { v4: uuidv4 } = require("uuid");
+const authQuery = require("../queries/authQuery");
 const userQuery = require("../queries/userQuery");
 const { getHashPassword } = require("../utils/getHashPassword");
 const { createAccessToken } = require("../utils/verifyToken");
 const URL = require("../constants/url");
+const { StatusCodes } = require("http-status-codes");
 
 const getGithubCallback = async (tokenUrl, data) => {
   try {
@@ -16,16 +18,13 @@ const getGithubCallback = async (tokenUrl, data) => {
     const { access_token } = requestToken;
 
     // 아이디
-    const { data: userdata } = await axios.get(`${URL.github_api}/user`, {
+    const { data: userdata } = await axios.get(URL.github_getUser, {
       headers: { Authorization: `token ${access_token}` },
     });
     // 이메일
-    const { data: emailDataArr } = await axios.get(
-      `${URL.github_api}/user/emails`,
-      {
-        headers: { Authorization: `token ${access_token}` },
-      }
-    );
+    const { data: emailDataArr } = await axios.get(URL.github_getEmail, {
+      headers: { Authorization: `token ${access_token}` },
+    });
 
     const userId = userdata.node_id;
 
@@ -38,10 +37,18 @@ const getGithubCallback = async (tokenUrl, data) => {
       const userName = userdata.login;
       const userEmail = emailDataArr[0].email;
       const pw = getHashPassword(uuidv4());
-      const values = [userId, userName, userEmail, pw.hashPassword, pw.salt];
+      const values = [
+        userId,
+        userName,
+        userEmail,
+        pw.hashPassword,
+        pw.salt,
+        "github",
+        access_token,
+      ];
 
       // 회원가입
-      await conn.query(userQuery.join, values);
+      await conn.query(authQuery.githubJoin, values);
     }
 
     // 로그인
@@ -58,6 +65,40 @@ const getGithubCallback = async (tokenUrl, data) => {
   }
 };
 
+const deleteGithubAccount = async (userId) => {
+  try {
+    // 토큰 꺼내기
+    const tokenResult = await conn.query(authQuery.getGithubToken, userId);
+    const { github_token } = tokenResult[0][0];
+
+    const response = await axios.delete(URL.github_deleteUser, {
+      headers: {
+        Authorization: `Basic ${Buffer.from(
+          `${process.env.GITHUB_CLIENT_ID}:${process.env.GITHUB_SECRET}`
+        ).toString("base64")}`,
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+      data: {
+        access_token: github_token,
+      },
+    });
+
+    if (response.status === 204) {
+      await conn.query(userQuery.deleteUser, userId); // db에서 제거
+
+      return {
+        isSuccess: true,
+        message: "회원 탈퇴 완료",
+      };
+    } else {
+      throw new CustomError(StatusCodes.FORBIDDEN, "회원 탈퇴 실패");
+    }
+  } catch (err) {
+    throw err;
+  }
+};
+
 module.exports = {
   getGithubCallback,
+  deleteGithubAccount,
 };

--- a/services/authService.js
+++ b/services/authService.js
@@ -1,0 +1,63 @@
+const { default: axios } = require("axios");
+const CustomError = require("../utils/CustomError");
+const conn = require("../database/mysql");
+const { v4: uuidv4 } = require("uuid");
+const userQuery = require("../queries/userQuery");
+const { getHashPassword } = require("../utils/getHashPassword");
+const { createAccessToken } = require("../utils/verifyToken");
+const URL = require("../constants/url");
+
+const getGithubCallback = async (tokenUrl, data) => {
+  try {
+    // 토큰 받아오기
+    const { data: requestToken } = await axios.post(tokenUrl, data, {
+      headers: { Accept: "application/json" },
+    });
+    const { access_token } = requestToken;
+
+    // 아이디
+    const { data: userdata } = await axios.get(`${URL.github_api}/user`, {
+      headers: { Authorization: `token ${access_token}` },
+    });
+    // 이메일
+    const { data: emailDataArr } = await axios.get(
+      `${URL.github_api}/user/emails`,
+      {
+        headers: { Authorization: `token ${access_token}` },
+      }
+    );
+
+    const userId = userdata.node_id;
+
+    // 유저 확인
+    const findResult = await conn.query(userQuery.getUserById, userId);
+    const existingUser = findResult[0][0];
+
+    // 없는 경우, 회원가입
+    if (!existingUser) {
+      const userName = userdata.login;
+      const userEmail = emailDataArr[0].email;
+      const pw = getHashPassword(uuidv4());
+      const values = [userId, userName, userEmail, pw.hashPassword, pw.salt];
+
+      // 회원가입
+      await conn.query(userQuery.join, values);
+    }
+
+    // 로그인
+    const token = createAccessToken(userId);
+
+    return {
+      isSuccess: true,
+      message: "로그인 성공",
+      accessToken: token,
+      userId,
+    };
+  } catch (err) {
+    throw new CustomError(StatusCodes.FORBIDDEN, "소셜 로그인 실패");
+  }
+};
+
+module.exports = {
+  getGithubCallback,
+};

--- a/services/userService.js
+++ b/services/userService.js
@@ -145,7 +145,6 @@ const getUser = async (userId) => {
           level: userData.level,
           totalPosts: count,
           totalPoints: userData.points,
-          loginType: userData.login_type,
         },
       };
     } else {

--- a/services/userService.js
+++ b/services/userService.js
@@ -145,6 +145,7 @@ const getUser = async (userId) => {
           level: userData.level,
           totalPosts: count,
           totalPoints: userData.points,
+          loginType: userData.login_type,
         },
       };
     } else {


### PR DESCRIPTION
## 📍 작업 내용
> 깃허브 소셜 로그인 구현
- 깃허브 로그인 요청 URL API
- 깃허브 로그인 API
- 회원탈퇴 API -> 깃허브 계정 회원탈퇴 분기 처리

<br/>

## 📍 기타 사항

### 📌 constants 폴더 생성
상수로 관리하면 좋은 값들은 이곳에서 관리하면 좋을 것 같습니다!
지금은 깃허브 로그인에 사용되는 엔드포인트들을 `URL` 이라는 상수로 관리하고 있어요. 필요한 경우 추가하시길
```js
const URL = {
  github_authorize: "https://github.com/login/oauth/authorize",
  // ...
}
```

### 📌 회원탈퇴 분기처리
users 테이블에 다음과 같은 2가지 속성을 추가했습니다.
- `login_type`: 로그인 유형 (default-기본, gitHub, goole)
- `github_token`: 깃허브 계정 탈퇴 시 사용되는 토큰

깃허브 계정도 회원탈퇴 버튼을 누르면 저희 서비스와 연동이 끊기게 하기 위해서 회원탈퇴 API에서 분기 처리를 했습니다. (login_type을 이용해서)
추후에 구글 로그인 추가되면 이것도 이 API에서 분기처리하면 될 것 같아요.
```js
const { login_type } = typeResult[0][0];

// 깃헙 계정인 경우
if (login_type === "github") {
  const result = await authService.deleteGithubAccount(userId);
  res.status(StatusCodes.OK).json(result);
}
// 일반 로그인의 경우
else {
  const result = await userService.deleteAccount(userId);
  res.status(StatusCodes.OK).json(result);
}
```

<br/>
