### PR TITLE
[Feat/#44]: 구글 로그인 구현

### DIFF
--- a/constants/url.js
+++ b/constants/url.js
@@ -4,6 +4,11 @@ const URL = {
   github_getEmail: "https://api.github.com/user/emails",
   github_getUser: "https://api.github.com/user",
   github_deleteUser: `https://api.github.com/applications/${process.env.GITHUB_CLIENT_ID}/grant`,
+
+  google_authorize: `https://accounts.google.com/o/oauth2/v2/auth`,
+  google_token: "https://oauth2.googleapis.com/token",
+  google_getUser: "https://www.googleapis.com/userinfo/v2/me",
+  google_deleteUser: `https://accounts.google.com/o/oauth2/revoke?token`,
 };
 
 module.exports = URL;

--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -53,8 +53,61 @@ const deleteGithubAccount = async (req, res) => {
   }
 };
 
+const getGoogleUrl = async (req, res) => {
+  try {
+    const url = URL.google_authorize;
+    const config = {
+      client_id: process.env.GOOGLE_CLIENT_ID,
+      redirect_uri: process.env.GOOGLE_REDIRECT_URI,
+      response_type: "code",
+      scope: "email profile",
+    };
+
+    const params = new URLSearchParams(config).toString();
+    const finalUrl = `${url}?${params}`;
+
+    res.status(StatusCodes.OK).json({ url: finalUrl });
+  } catch (err) {
+    res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+      isSuccess: false,
+      message: err.message,
+    });
+  }
+};
+
+const getGoogleCallback = async (req, res) => {
+  const { code } = req.body;
+
+  if (!code) {
+    return res.status(StatusCodes.BAD_REQUEST).json({
+      isSuccess: false,
+      message: "Authorization code is missing",
+    });
+  }
+
+  const params = {
+    code,
+    client_id: process.env.GOOGLE_CLIENT_ID,
+    client_secret: process.env.GOOGLE_CLIENT_SECRET,
+    redirect_uri: process.env.GOOGLE_REDIRECT_URI,
+    grant_type: "authorization_code",
+  };
+
+  try {
+    const result = await authService.getGoogleCallback(params);
+    res.status(StatusCodes.OK).json(result);
+  } catch (err) {
+    res.status(err.statusCode || 500).json({
+      isSuccess: false,
+      message: err.message,
+    });
+  }
+};
+
 module.exports = {
   getGithubUrl,
   getGithubCallback,
   deleteGithubAccount,
+  getGoogleUrl,
+  getGoogleCallback,
 };

--- a/queries/authQuery.js
+++ b/queries/authQuery.js
@@ -1,2 +1,5 @@
 exports.githubJoin = `INSERT INTO users (id, name, email, password, salt, login_type, github_token) VALUES (?, ?, ?, ?, ?, ?, ?)`;
 exports.getGithubToken = `SELECT github_token FROM users WHERE id = ?`;
+
+exports.googleJoin = `INSERT INTO users (id, name, email, password, salt, login_type, google_token) VALUES (?, ?, ?, ?, ?, ?, ?)`;
+exports.getGoogleToken = `SELECT google_token FROM users WHERE id = ?`;

--- a/routes/authRouter.js
+++ b/routes/authRouter.js
@@ -6,4 +6,7 @@ authRouter.get("/github", authController.getGithubUrl);
 authRouter.post("/github", authController.getGithubCallback);
 authRouter.delete("/github", authController.deleteGithubAccount);
 
+authRouter.get("/google", authController.getGoogleUrl);
+authRouter.post("/google", authController.getGoogleCallback);
+
 module.exports = authRouter;


### PR DESCRIPTION
## 📍 작업 내용

구글 로그인 로직
1. GET /ouath/goole으로 응답으로 전해진 url을 누르면 구글 로그인 화면 뜸
<img width="1624" alt="스크린샷 2024-07-07 오후 6 33 37" src="https://github.com/Team-DevHub/dev-hub-back/assets/124678039/80388e1b-9c16-4616-96ab-b9e48db1ad1e">
<img width="1624" alt="스크린샷 2024-07-07 오후 6 36 25" src="https://github.com/Team-DevHub/dev-hub-back/assets/124678039/f137613e-ebfe-4992-b755-2de1492797c0">

2. 로그인 성공하면 리디렉션된 url에 code(인가 코드)가 쿼리스트링으로 붙어서 나옴
<img width="1624" alt="스크린샷 2024-07-07 오후 6 37 47" src="https://github.com/Team-DevHub/dev-hub-back/assets/124678039/df0f6a0d-de62-4af5-90c2-ade224fa5e75">

3. 해당 코드값을 POST /oauth/google을 통해 req.body로 디코딩해서 보내주면 로그인 성공과 함께 응답이 뜸
(해당 화면의 코드값은 이전에 테스트한 코드라 좀 달라요)
<img width="1624" alt="스크린샷 2024-07-08 오전 3 01 24" src="https://github.com/Team-DevHub/dev-hub-back/assets/124678039/1061789f-c840-4b10-ad62-16498bca8df1">

4. 구글 회원가입 회원은 DB에 google_token이 저장됨

<br/>

## 📍 기타 사항

<br/>
