### PR TITLE
[Feat/#53]: Google 로그인 계정 해지(탈퇴)

### DIFF
--- a/constants/url.js
+++ b/constants/url.js
@@ -8,7 +8,7 @@ const URL = {
   google_authorize: `https://accounts.google.com/o/oauth2/v2/auth`,
   google_token: "https://oauth2.googleapis.com/token",
   google_getUser: "https://www.googleapis.com/userinfo/v2/me",
-  google_deleteUser: `https://accounts.google.com/o/oauth2/revoke?token`,
+  google_deleteUser: `https://accounts.google.com/o/oauth2/revoke?token=`,
 };
 
 module.exports = URL;

--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -101,10 +101,23 @@ const getGoogleCallback = async (req, res) => {
   }
 };
 
+const deleteGoogleAccount = async (req, res) => {
+  try {
+    const result = await authService.deleteGoogleAccount(req.userId);
+    res.status(StatusCodes.OK).json(result);
+  } catch (err) {
+    res.status(err.statusCode || 500).json({
+      isSuccess: false,
+      message: err.message,
+    });
+  }
+};
+
 module.exports = {
   getGithubUrl,
   getGithubCallback,
   deleteGithubAccount,
   getGoogleUrl,
   getGoogleCallback,
+  deleteGoogleAccount,
 };

--- a/controllers/usersController.js
+++ b/controllers/usersController.js
@@ -114,6 +114,9 @@ const deleteAccount = [
       if (login_type === "github") {
         const result = await authService.deleteGithubAccount(userId);
         res.status(StatusCodes.OK).json(result);
+      } else if (login_type === "google") {
+        const result = await authService.deleteGoogleAccount(userId);
+        res.status(StatusCodes.OK).json(result);
       } else {
         const result = await userService.deleteAccount(userId);
         res.status(StatusCodes.OK).json(result);

--- a/routes/authRouter.js
+++ b/routes/authRouter.js
@@ -9,5 +9,6 @@ authRouter.delete("/github", tokenHandler, authController.deleteGithubAccount);
 
 authRouter.get("/google", authController.getGoogleUrl);
 authRouter.post("/google", authController.getGoogleCallback);
+authRouter.delete("/google", tokenHandler, authController.deleteGoogleAccount);
 
 module.exports = authRouter;

--- a/services/authService.js
+++ b/services/authService.js
@@ -144,8 +144,34 @@ const getGoogleCallback = async (params) => {
   }
 };
 
+const deleteGoogleAccount = async (userId) => {
+  try {
+    const tokenResult = await conn.query(authQuery.getGoogleToken, userId);
+    const { google_token } = tokenResult[0][0];
+
+    const response = await axios.get(`${URL.google_deleteUser}${google_token}`);
+
+    if (response.status === 200) {
+      await conn.query(userQuery.deleteUser, userId);
+
+      return {
+        isSuccess: true,
+        message: "회원 탈퇴 완료",
+      };
+    } else {
+      throw new CustomError(
+        StatusCodes.BAD_REQUEST,
+        "구글 회원 계정 해지 실패"
+      );
+    }
+  } catch (err) {
+    throw err;
+  }
+};
+
 module.exports = {
   getGithubCallback,
   deleteGithubAccount,
   getGoogleCallback,
+  deleteGoogleAccount,
 };


### PR DESCRIPTION
## 📍 작업 내용

1. usersController.js login_type 분기 추가
```js
if (login_type === "github") {
        const result = await authService.deleteGithubAccount(userId);
        res.status(StatusCodes.OK).json(result);
      } else if (login_type === "google") {
        const result = await authService.deleteGoogleAccount(userId);
        res.status(StatusCodes.OK).json(result);
      } else {
        const result = await userService.deleteAccount(userId);
        res.status(StatusCodes.OK).json(result);
      }
```

2. authService.js 함수 추가
`https://accounts.google.com/o/oauth2/revoke?token=${google_token}`
으로 구글 계정 해지 요청
해당 액세스 토큰을 가진 userId를 DB에서 삭제함

<br/>

## 📍 기타 사항

리뷰어가 특별히 봐주었으면 하는 부분이나 주의사항, 알림사항 등이 있다면 작성해주세요.

<br/>
