### PR TITLE
[Fix/#56]: 게시글 상세 조회 > 스크랩 여부 오류 수정

### DIFF
--- a/controllers/postController.js
+++ b/controllers/postController.js
@@ -131,9 +131,10 @@ const getPostDetail = [
   valid.validationCheck,
   async (req, res) => {
     const { postId } = req.params;
+    const { userId } = req.body;
 
     try {
-      const result = await postService.getPostDetail(postId);
+      const result = await postService.getPostDetail(postId, userId);
       res.status(StatusCodes.OK).json(result);
     } catch (err) {
       res.status(err.statusCode || 400).json({

--- a/queries/scrapQuery.js
+++ b/queries/scrapQuery.js
@@ -3,4 +3,3 @@ exports.getScrapPosts = `SELECT id as postId, title, category_id as categoryId, 
 exports.scrap = `INSERT INTO scraps (post_id, user_id) VALUES (?, ?)`;
 exports.getScrapCount = `SELECT COUNT(*) as count FROM scraps WHERE post_id = ? AND user_id = ?`;
 exports.deleteScrap = `DELETE FROM scraps WHERE user_id = ? AND post_id = ?`;
-exports.countScrapById = `SELECT COUNT(*) as count FROM scraps WHERE post_id = ?`;

--- a/services/postService.js
+++ b/services/postService.js
@@ -94,7 +94,7 @@ const getPosts = async (query, params, countQuery, countParams, page) => {
   }
 };
 
-const getPostDetail = async (postId) => {
+const getPostDetail = async (postId, userId) => {
   try {
     const postResult = await conn.query(postQuery.getPostById, postId);
     const postData = postResult[0][0];
@@ -141,11 +141,14 @@ const getPostDetail = async (postId) => {
     const postWriter = await getUserInfo(postData.writer_id);
 
     // 스크랩 여부
-    const { count } = await conn
-      .query(scrapQuery.countScrapById, postId)
-      .then((res) => res[0][0]);
-    const isScrapped = count > 0 ? true : false;
+    let isScrapped = null;
+    if (userId) {
+      const { count } = await conn
+        .query(scrapQuery.getScrapCount, [postId, userId])
+        .then((res) => res[0][0]);
 
+      isScrapped = count > 0 ? true : false;
+    }
     // 게시글 상세 조회
     const postInfo = {
       postId: postData.id,


### PR DESCRIPTION
## 📍 작업 내용
> 게시글 상세 조회 > 스크랩 여부 오류 수정

body로 userId가 전달될 경우 해당 유저가 게시글을 스크랩 하였는지에 대한 여부를 전달하고,
그렇지 않은 경우 null을 반환하도록 수정했습니다!

```js
// 스크랩 여부
    let isScrapped = null;
    if (userId) {
      const { count } = await conn
        .query(scrapQuery.getScrapCount, [postId, userId])
        .then((res) => res[0][0]);

      isScrapped = count > 0 ? true : false;
    }
```

<br/>

## 📍 기타 사항

<br/>
