### PR TITLE
[Fix/#55]: Google 회원 탈퇴 오류 수정

### DIFF
--- a/queries/authQuery.js
+++ b/queries/authQuery.js
@@ -1,5 +1,6 @@
 exports.githubJoin = `INSERT INTO users (id, name, email, password, salt, login_type, github_token) VALUES (?, ?, ?, ?, ?, ?, ?)`;
 exports.getGithubToken = `SELECT github_token FROM users WHERE id = ?`;
 
-exports.googleJoin = `INSERT INTO users (id, name, email, password, salt, login_type, google_token) VALUES (?, ?, ?, ?, ?, ?, ?)`;
-exports.getGoogleToken = `SELECT google_token FROM users WHERE id = ?`;
+exports.googleJoin = `INSERT INTO users (id, name, email, password, salt, login_type, google_token, refresh_token) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`;
+exports.getGoogleRefreshToken = `SELECT refresh_token FROM users WHERE id = ?`;
+exports.updateGoogleToken = `UPDATE users SET google_token = ? WHERE id = ?`;

--- a/services/authService.js
+++ b/services/authService.js
@@ -98,13 +98,10 @@ const deleteGithubAccount = async (userId) => {
   }
 };
 
-const getGoogleCallback = async (params) => {
+const getGoogleCallback = async (tokens) => {
   try {
-    const { data: tokenData } = await axios.post(URL.google_token, params, {
-      headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    });
-
-    const { access_token } = tokenData;
+    const access_token = tokens.access_token;
+    const refresh_token = tokens.refresh_token ? tokens.refresh_token : null;
 
     const { data: userInfo } = await axios.get(URL.google_getUser, {
       headers: { Authorization: `Bearer ${access_token}` },
@@ -127,8 +124,14 @@ const getGoogleCallback = async (params) => {
         pw.salt,
         "google",
         access_token,
+        refresh_token,
       ];
+
       await conn.query(authQuery.googleJoin, values);
+    } else {
+      // 기존 구글 회원인 경우
+      const updateValues = [access_token, id];
+      await conn.query(authQuery.updateGoogleToken, updateValues);
     }
 
     const token = createAccessToken(id);
@@ -146,23 +149,26 @@ const getGoogleCallback = async (params) => {
 
 const deleteGoogleAccount = async (userId) => {
   try {
-    const tokenResult = await conn.query(authQuery.getGoogleToken, userId);
-    const { google_token } = tokenResult[0][0];
+    const tokenResult = await conn.query(
+      authQuery.getGoogleRefreshToken,
+      userId
+    );
+    const { refresh_token } = tokenResult[0][0];
 
-    const response = await axios.get(`${URL.google_deleteUser}${google_token}`);
+    const response = await axios.get(
+      `${URL.google_deleteUser}${refresh_token}`
+    );
 
     if (response.status === 200) {
+      // db에서 user 삭제
       await conn.query(userQuery.deleteUser, userId);
 
       return {
         isSuccess: true,
-        message: "회원 탈퇴 완료",
+        message: "구글 회원 탈퇴 완료",
       };
     } else {
-      throw new CustomError(
-        StatusCodes.BAD_REQUEST,
-        "구글 회원 계정 해지 실패"
-      );
+      throw new CustomError(StatusCodes.FORBIDDEN, "구글 회원 탈퇴 실패");
     }
   } catch (err) {
     throw err;


### PR DESCRIPTION
## 📍 작업 내용

- 구글 회원 가입 시, refresh token을 추가로 받아옴
- 회원 탈퇴 시, jwt을 헤더에 넣으면 해당 userId를 가진 회원의 refresh token을 DB에서 찾아 revoke 시켜주고 DB삭제 (회원 탈퇴)

<br/>

## 📍 기타 사항

DB에서 구글 토큰컬럼은 일단 안 빼놓았습니다!

<br/>
